### PR TITLE
Explict network

### DIFF
--- a/packages/use-contractkit/src/ethers.ts
+++ b/packages/use-contractkit/src/ethers.ts
@@ -6,11 +6,12 @@ import { useContractKit } from './use-contractkit';
 import { useIsMounted } from './utils/useIsMounted';
 
 export const useProvider = (): Web3Provider => {
-  const { kit } = useContractKit();
+  const { kit, network } = useContractKit();
+  const {chainId, name} = network
   const provider = kit.web3.currentProvider as unknown as ExternalProvider;
   return useMemo(() => {
-    return new Web3Provider(provider);
-  }, [provider]);
+    return new Web3Provider(provider, {chainId, name});
+  }, [provider, chainId, name]);
 };
 
 export const useProviderOrSigner = (): Web3Provider | JsonRpcSigner => {

--- a/packages/use-contractkit/src/ethers.ts
+++ b/packages/use-contractkit/src/ethers.ts
@@ -7,10 +7,10 @@ import { useIsMounted } from './utils/useIsMounted';
 
 export const useProvider = (): Web3Provider => {
   const { kit, network } = useContractKit();
-  const {chainId, name} = network
+  const { chainId, name } = network;
   const provider = kit.web3.currentProvider as unknown as ExternalProvider;
   return useMemo(() => {
-    return new Web3Provider(provider, {chainId, name});
+    return new Web3Provider(provider, { chainId, name });
   }, [provider, chainId, name]);
 };
 
@@ -25,8 +25,9 @@ export const useProviderOrSigner = (): Web3Provider | JsonRpcSigner => {
 };
 
 export const useGetConnectedSigner = (): (() => Promise<JsonRpcSigner>) => {
-  const { kit, getConnectedKit } = useContractKit();
+  const { kit, getConnectedKit, network } = useContractKit();
   const signer = useProviderOrSigner();
+  const { chainId, name } = network;
   return useCallback(async () => {
     if (kit.defaultAccount) {
       return signer as JsonRpcSigner;
@@ -34,8 +35,10 @@ export const useGetConnectedSigner = (): (() => Promise<JsonRpcSigner>) => {
     const nextKit = await getConnectedKit();
     const nextProvider = nextKit.web3
       .currentProvider as unknown as ExternalProvider;
-    return new Web3Provider(nextProvider).getSigner(nextKit.defaultAccount);
-  }, [kit.defaultAccount, getConnectedKit, signer]);
+    return new Web3Provider(nextProvider, { chainId, name }).getSigner(
+      nextKit.defaultAccount
+    );
+  }, [kit.defaultAccount, getConnectedKit, signer, chainId, name]);
 };
 
 export const useLazyConnectedSigner = (): {


### PR DESCRIPTION
pass networkish to Web3Provider from useProvider and useGetConnectedSigner so that we can avoid querying the node for the network which is a waste since we already know it. 



avoids this code from JSON-RPC-Provider
```
  constructor(url?: ConnectionInfo | string, network?: Networkish) {
        logger.checkNew(new.target, JsonRpcProvider);

        let networkOrReady: Networkish | Promise<Network> = network;

        // The network is unknown, query the JSON-RPC for it
        if (networkOrReady == null) {
            networkOrReady = new Promise((resolve, reject) => {
                setTimeout(() => {
                    this.detectNetwork().then((network) => {
                        resolve(network);
                    }, (error) => {
                        reject(error);
                    });
                }, 0);
            });
        }
```